### PR TITLE
Corrigindo o comportamento da função 'conversaoDeBytes'

### DIFF
--- a/main.c
+++ b/main.c
@@ -112,7 +112,7 @@ void conversaoDeBytes(void){
 
     int tamanhoOpcoes = sizeof(opcoes) / sizeof(opcoes[0]);
 
-    int opcoesValidas[] = {1,2,3,4,5};
+    int opcoesValidas[] = {0,1,2,3,4,5};
 
     int tamanhoOpcoesValidas = sizeof(opcoesValidas) / sizeof(opcoesValidas[0]);
 
@@ -139,6 +139,8 @@ void conversaoDeBytes(void){
 
     primeiraOpcao = obterInputDoUsuario(opcoesValidas,tamanhoOpcoesValidas);
 
+    if(primeiraOpcao == 0) return;
+
     removerDasOpcoesValidasPorIndex(opcoesValidas,&tamanhoOpcoesValidas,primeiraOpcao-1);
 
     printf("\n\nPara qual unidade deseja converter?\n\n");
@@ -148,6 +150,8 @@ void conversaoDeBytes(void){
     printf("Informe sua escolha: ");
 
     segundaOpcao = obterInputDoUsuario(opcoesValidas,tamanhoOpcoesValidas);
+
+    if(segundaOpcao == 0) return;
 
     printf("\nVocê escolheu converter %s para %s.\n", opcoes[primeiraOpcao - 1], opcoes[segundaOpcao - 1]);
 
@@ -189,15 +193,11 @@ int obterInputDoUsuario(int opcoesValidas[],int tamanho){
 
     scanf("%d",&valor);
 
-    if(valor == 0) exit(0);
-
     while (!opcaoValida(valor,opcoesValidas,tamanho))
     {
         printf("\nA opção escolhida é inválida, tente novamente: ");
 
         scanf("%d",&valor);
-
-        if(valor == 0) exit(0);
     }
 
     return valor;


### PR DESCRIPTION
Este PR corrige o comportamento da função 'conversãoDeBytes', que antes encerrava o programa quando a opção 'sair' era selecionada, ao invés de retornar para o menu principal.